### PR TITLE
create bindir when doing install

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -18,6 +18,7 @@ $(APP): $(OBJS)
 	$(CC) -o $@ -c $< $(CFLAGS)
 
 install:
+	mkdir -p $(DESTDIR)$(bindir)
 	cp $(APP) $(DESTDIR)$(bindir)
 	mkdir -p $(DESTDIR)$(mandir)/man1
 	cp $(MANPAGE) $(DESTDIR)$(mandir)/man1


### PR DESCRIPTION
If install is executed in the true empty DESTDIR, the installation will fail as the bindir directory is missing.
Fix this by creating the bindir (same as it is already being done for te mandir.
