### PR TITLE
potential improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+config.log
+config.status
+*.o

--- a/pdf.c
+++ b/pdf.c
@@ -1112,6 +1112,7 @@ static char *get_object(
         if (total_sz + blk_sz >= (blk_sz * n_blks))
           data = realloc(data, blk_sz * (++n_blks));
         if (!data) {
+          free(data);
           ERR("Failed to reallocate buffer.\n");
           exit(EXIT_FAILURE);
         }

--- a/pdf.c
+++ b/pdf.c
@@ -1178,6 +1178,11 @@ static void load_kids(FILE *fp, int pages_id, xref_t *xref)
     }
     
     c = strchr(c, '[');
+    if (c == NULL)
+    {
+        free(data);
+        return;
+    }
     buf_idx = 0;
     memset(buf, 0, sizeof(buf));
     while (*(++c) != ']')

--- a/pdf.c
+++ b/pdf.c
@@ -1154,6 +1154,7 @@ static void add_kid(int id, xref_t *xref)
     xref->kids[xref->n_kids++] = id;
 }
 
+static int kids_count = 0;
 
 /* Recursive */
 static void load_kids(FILE *fp, int pages_id, xref_t *xref)
@@ -1161,6 +1162,13 @@ static void load_kids(FILE *fp, int pages_id, xref_t *xref)
     int   dummy, buf_idx, kid_id;
     char *data, *c, buf[32];
 
+    kids_count++;
+    if (kids_count > 1000)
+    {
+        printf("error: recursive load_kids\n");
+        exit(1);
+    }
+    
     /* Get kids */
     data = get_object(fp, pages_id, xref, NULL, &dummy);
     if (!data || !(c = strstr(data, "/Kids")))

--- a/pdf.c
+++ b/pdf.c
@@ -688,7 +688,7 @@ static void load_xref_from_plaintext(FILE *fp, xref_t *xref)
                 exit(EXIT_FAILURE);
             }
             xref->entries[i].offset = atol(token_result);
-            token_result = strtoke(NULL, " ");
+            token_result = strtok(NULL, " ");
             if (!token_result)
             {
                 ERR("failed to tokenize string\n");

--- a/pdf.c
+++ b/pdf.c
@@ -932,6 +932,8 @@ static void load_creator_from_old_format(
     int            i, n_eles, length, is_escaped, obj_id;
     char          *c, *ascii, *start, *s, *saved_buf_search, *obj;
     pdf_creator_t *info;
+    size_t         obj_size;
+    int            loop_counter;
 
     info = new_creator(&n_eles);
 
@@ -959,12 +961,21 @@ static void load_creator_from_old_format(
             saved_buf_search = c;
             s = saved_buf_search;
 
-            obj = get_object(fp, obj_id, xref, NULL, NULL);
+            obj = get_object(fp, obj_id, xref, &obj_size, NULL);
             c = obj;
+            loop_counter = 0;
+            
+            if (obj_size == 0)
+                break;
 
             /* Iterate to '(' */
             while (c && (*c != '('))
-             ++c;
+            {
+                loop_counter++;
+                if (loop_counter > (int)obj_size)
+                    break;
+                ++c;
+            }
 
             /* Advance the search to the next token */
             while (s && (*s == '/'))

--- a/pdf.c
+++ b/pdf.c
@@ -964,8 +964,6 @@ static void load_creator_from_old_format(
     char          *c, *ascii, *start, *s, *saved_buf_search, *obj;
     size_t         obj_size;
     pdf_creator_t *info;
-    size_t         obj_size;
-    int            loop_counter;
 
     info = new_creator(&n_eles);
 
@@ -1011,7 +1009,6 @@ static void load_creator_from_old_format(
             obj = get_object(fp, obj_id, xref, &obj_size, NULL);
             end = obj + obj_size;
             c = obj;
-            loop_counter = 0;
             
             if (obj_size == 0)
                 break;

--- a/pdf.c
+++ b/pdf.c
@@ -679,9 +679,22 @@ static void load_xref_from_plaintext(FILE *fp, xref_t *xref)
         /* Entry or object id */
         if (strlen(buf) > 17)
         {
+            char *token_result;
             xref->entries[i].obj_id = obj_id++;
-            xref->entries[i].offset = atol(strtok(buf, " "));
-            xref->entries[i].gen_num = atoi(strtok(NULL, " "));
+            token_result = strtok(buf, " ");
+            if (!token_result)
+            {
+                ERR("failed to tokenize string\n");
+                exit(EXIT_FAILURE);
+            }
+            xref->entries[i].offset = atol(token_result);
+            token_result = strtoke(NULL, " ");
+            if (!token_result)
+            {
+                ERR("failed to tokenize string\n");
+                exit(EXIT_FAILURE);
+            }
+            xref->entries[i].gen_num = atoi(token_result);
             xref->entries[i].f_or_n = buf[17];
             ++added_entries;
         }


### PR DESCRIPTION
Hello,
I found what I think are a few cases where error handling can be improved.  Any chance you can take a look at these?

- For the recursive load_kids() calls I have found an input (id-000022.tmin) that causes a crash without the fix
- Similarly for the strtok calls I found an input (id-000000.tmin) that causes a crash.
- The freeing of data before exiting is just to clear up valgrind output

Thanks!